### PR TITLE
Fix links to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To facilitate the evaluation of LLMs on BigCodeBench, we provide this Python pac
 
 BigCodeBench focuses on the evaluation of LLM4Code with *diverse function calls* and *complex instruction*, with:
 
-* ✨ **Precise evaluation & ranking**: See [our leaderboard](https://bigcode-bench.github.io/leaderboard.html) for latest LLM rankings before & after rigorous evaluation.
+* ✨ **Precise evaluation & ranking**: See [our leaderboard](https://huggingface.co/spaces/bigcode/bigcodebench-leaderboard) for latest LLM rankings before & after rigorous evaluation.
 * ✨ **Pre-generated samples**: BigCodeBench accelerates code intelligence research by open-sourcing [LLM-generated samples](#-LLM-generated-code) for various models -- no need to re-run the expensive benchmarks!
 
 ### Main Differences from EvalPlus

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To facilitate the evaluation of LLMs on BigCodeBench, we provide this Python pac
 
 BigCodeBench focuses on the evaluation of LLM4Code with *diverse function calls* and *complex instruction*, with:
 
-* ✨ **Precise evaluation & ranking**: See [our leaderboard](https://bigcodebench.github.io/leaderboard.html) for latest LLM rankings before & after rigorous evaluation.
+* ✨ **Precise evaluation & ranking**: See [our leaderboard](https://bigcode-bench.github.io/leaderboard.html) for latest LLM rankings before & after rigorous evaluation.
 * ✨ **Pre-generated samples**: BigCodeBench accelerates code intelligence research by open-sourcing [LLM-generated samples](#-LLM-generated-code) for various models -- no need to re-run the expensive benchmarks!
 
 ### Main Differences from EvalPlus
@@ -328,7 +328,7 @@ python get_results.py
 
 ## 💻 LLM-generated Code
 
-We share pre-generated code samples from LLMs we have [evaluated](https://bigcodebench.github.io/leaderboard.html):
+We share pre-generated code samples from LLMs we have [evaluated](https://bigcode-bench.github.io/leaderboard.html):
 *  See the attachment of our [v0.1.2](https://github.com/bigcode-project/bigcodebench/releases/tag/v0.1.5). We include both `sanitized_samples.zip` and `sanitized_samples_calibrated.zip` for your convenience.
 
 ## Known Issues


### PR DESCRIPTION
The links in README seemed to be broken. Fixing with new links.