### PR TITLE
add multiprocessing support for sanitization step

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ We provide a tool namely `bigcodebench.sanitize` to clean up the code:
 bigcodebench.sanitize --samples samples.jsonl --calibrate
 # Sanitized code will be produced to `samples-sanitized-calibrated.jsonl`
 
+# 💡 Optionally run the sanitization step with multiprocessing to speedup
+bigcodebench.sanitize --samples samples.jsonl --calibrate --parallel 8
+
 # 💡 If you want to get the original results:
 bigcodebench.sanitize --samples samples.jsonl
 # Sanitized code will be produced to `samples-sanitized.jsonl`

--- a/Requirements/requirements.txt
+++ b/Requirements/requirements.txt
@@ -1,6 +1,7 @@
 appdirs>=1.4.4
 fire>=0.6.0
 multipledispatch>=0.6.0
+pqdm>=0.2.0
 tempdir>=0.7.1
 termcolor>=2.0.0
 tqdm>=4.56.0


### PR DESCRIPTION
Allow sanitization of generations in multiprocessing context to speed up this step significantly.

Invocation remains the unchanged

```shell
bigcodebench.sanitize --samples output.jsonl --calibrate
```

or

```shell
bigcodebench.sanitize --samples output.jsonl --calibrate --parallel 64
```