### PR TITLE
Await futures in progress checker

### DIFF
--- a/bigcodebench/evaluate.py
+++ b/bigcodebench/evaluate.py
@@ -6,7 +6,7 @@ import pickle
 import threading
 import time
 from collections import Counter, defaultdict
-from concurrent.futures import ProcessPoolExecutor, as_completed, wait, ALL_COMPLETED
+from concurrent.futures import ProcessPoolExecutor, as_completed, wait, FIRST_COMPLETED
 from datetime import datetime
 from typing import Any, Dict, List, Tuple
 from warnings import warn
@@ -204,9 +204,9 @@ def evaluate(flags):
             assert len(completion_id) == len(problems), "Missing problems in samples"
 
             def stucking_checker():
-                not_done = [True]
+                not_done = futures
                 while len(not_done) > 0:
-                    done, not_done = wait(futures, timeout=240, return_when=ALL_COMPLETED)
+                    done, not_done = wait(not_done, timeout=240, return_when=FIRST_COMPLETED)
 
                     if len(done) == 0:
                         warn("No samples have finished testing in the last 240s")

--- a/bigcodebench/evaluate.py
+++ b/bigcodebench/evaluate.py
@@ -209,7 +209,6 @@ def evaluate(flags):
                     done, not_done = wait(futures, timeout=240, return_when=ALL_COMPLETED)
 
                     if len(done) == 0:
-                        # Output warnings after 240 seconds of no change
                         warn("No samples have finished testing in the last 240s")
                         warn(f"{len(remainings)} samples to be tested: {remainings}")
 

--- a/bigcodebench/evaluate.py
+++ b/bigcodebench/evaluate.py
@@ -204,14 +204,26 @@ def evaluate(flags):
             assert len(completion_id) == len(problems), "Missing problems in samples"
 
             def stucking_checker():
+                unchanged_duration = 0
+                last_size = len(remainings)
+
                 while remainings:
-                    last_size = len(remainings)
-                    time.sleep(240)
-                    if last_size != len(remainings) or len(remainings) == 0:
-                        continue
-                    # Potential stucking
-                    warn("No samples had finished testing in the last 240s")
-                    warn(f"{len(remainings)} samples to be tested: {remainings}")
+                    time.sleep(1)
+                    current_size = len(remainings)
+
+                    if current_size != last_size or current_size == 0:
+                        # Reset the unchanged duration if something has changed
+                        unchanged_duration = 0
+                        last_size = current_size
+                    else:
+                        # Increment the duration if nothing has changed
+                        unchanged_duration += 1
+
+                    if unchanged_duration >= 240:
+                        # Output warnings after 240 seconds of no change
+                        warn("No samples have finished testing in the last 240s")
+                        warn(f"{len(remainings)} samples to be tested: {remainings}")
+                        unchanged_duration = 0  # Reset after warning
 
             threading.Thread(target=stucking_checker).start()
 


### PR DESCRIPTION
Before this fix, the progress checker would pause for 240 seconds, causing the program to potentially wait that long after all evaluations were complete.

This PR changes the logic so that the progress checker now checks for updates every second, but only displays a warning if no progress has been made in the past 240 seconds. Once all tasks are finished, the thread will terminate.

Fixes #42