### PR TITLE
Fixes for tasks 211 and 215

### DIFF
--- a/tools/fix_v022.py
+++ b/tools/fix_v022.py
@@ -11,6 +11,47 @@ BIGCODEBENCH_UPDATE = "bigcode/bcb_update"
 BIGCODEBENCH_NEW_VERSION = "v0.1.3"
 
 def map_ds(sample):
+    if sample["task_id"] in ["BigCodeBench/211"]:
+        sample['test'] = sample['test'].replace(
+"""
+        mock_response = MagicMock()
+        mock_response.content = MOCK_CONTENT
+""",
+"""
+        mock_response = MagicMock()
+        mock_response.content = MOCK_CONTENT
+        mock_response.status_code = 200
+"""
+        )
+    if sample["task_id"] in ["BigCodeBench/215"]:
+        sample['test'] = sample['test'].replace(
+"""
+        mock_response = Mock()
+""",
+"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+"""
+        )
+        sample['test'] = sample['test'].replace(
+"""
+        mock_response.text =""",
+"""
+        MOCK_TEXT ="""
+        )
+        sample['test'] = sample['test'].replace(
+"""
+        mock_get.return_value = mock_response
+""",
+"""
+        mock_response.text = MOCK_TEXT
+        mock_response.json = lambda: json.loads(MOCK_TEXT)
+        mock_get.return_value = mock_response
+"""
+        )
+        sample['complete_prompt'] = sample['complete_prompt'].replace("Thif function will raise", "This function will raise")
+        sample['instruct_prompt'] = sample['instruct_prompt'].replace("Thif function will raise", "This function will raise")
+        sample['doc_struct'] = sample['doc_struct'].replace("Thif function will raise", "This function will raise")
     if sample["task_id"] in ["BigCodeBench/1005"]:
         for k in sample.keys():
             sample[k] = sample[k].replace(
@@ -28,7 +69,7 @@ if __name__ == "__main__":
     hard_ds_dict = load_dataset(BIGCODEBENCH_HARD_HF)
     ds = ds_dict[BIGCODEBENCH_VERSION]
     hard_ds = hard_ds_dict[BIGCODEBENCH_VERSION]
-    function_id = [1005]
+    function_id = [211, 215, 1005]
     
     new_ds = ds.map(map_ds)
     new_ds.to_json("BigCodeBench.jsonl")

--- a/tools/fix_v023.py
+++ b/tools/fix_v023.py
@@ -6,20 +6,52 @@ import copy
 
 BIGCODEBENCH_HF = "bigcode/bigcodebench"
 BIGCODEBENCH_HARD_HF = "bigcode/bigcodebench-hard"
-BIGCODEBENCH_VERSION = "v0.1.2"
+BIGCODEBENCH_VERSION = "v0.1.3"
 BIGCODEBENCH_UPDATE = "bigcode/bcb_update"
-BIGCODEBENCH_NEW_VERSION = "v0.1.3"
+BIGCODEBENCH_NEW_VERSION = "v0.1.4"
 
 def map_ds(sample):
-    if sample["task_id"] in ["BigCodeBench/1005"]:
-        for k in sample.keys():
-            sample[k] = sample[k].replace(
-                "https://getsamplefiles.com/download/zip/sample-2.zip", "https://getsamplefiles.com/download/zip/sample-5.zip"
-            ).replace(
-                "sample_2", "sample_5"
-            ).replace(
-                "Sample 2", "Sample 5"
-            )
+    if sample["task_id"] in ["BigCodeBench/211"]:
+        sample['test'] = sample['test'].replace(
+"""
+        mock_response = MagicMock()
+        mock_response.content = MOCK_CONTENT
+""",
+"""
+        mock_response = MagicMock()
+        mock_response.content = MOCK_CONTENT
+        mock_response.status_code = 200
+"""
+        )
+    if sample["task_id"] in ["BigCodeBench/215"]:
+        sample['test'] = sample['test'].replace(
+"""
+        mock_response = Mock()
+""",
+"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+"""
+        )
+        sample['test'] = sample['test'].replace(
+"""
+        mock_response.text =""",
+"""
+        MOCK_TEXT ="""
+        )
+        sample['test'] = sample['test'].replace(
+"""
+        mock_get.return_value = mock_response
+""",
+"""
+        mock_response.text = MOCK_TEXT
+        mock_response.json = lambda: json.loads(MOCK_TEXT)
+        mock_get.return_value = mock_response
+"""
+        )
+        sample['complete_prompt'] = sample['complete_prompt'].replace("Thif function will raise", "This function will raise")
+        sample['instruct_prompt'] = sample['instruct_prompt'].replace("Thif function will raise", "This function will raise")
+        sample['doc_struct'] = sample['doc_struct'].replace("Thif function will raise", "This function will raise")
     return sample
     
 if __name__ == "__main__":
@@ -28,7 +60,7 @@ if __name__ == "__main__":
     hard_ds_dict = load_dataset(BIGCODEBENCH_HARD_HF)
     ds = ds_dict[BIGCODEBENCH_VERSION]
     hard_ds = hard_ds_dict[BIGCODEBENCH_VERSION]
-    function_id = [1005]
+    function_id = [211, 215]
     
     new_ds = ds.map(map_ds)
     new_ds.to_json("BigCodeBench.jsonl")


### PR DESCRIPTION
This PR adds `200 OK` status code for the mocks in task 211 and 215. For 215 it also adds the option to use `response.json()` and fixes a spelling error in the description.

**Test results for `starcoder2-15b`:**

- **BigCodeBench/211:** Progressed past the HTTP error, but saves the zip file to the current directory as opposed to the destination directory. It is actually not specified in the description of the task where to save the zip file. This might be addressed with and update to the task specification or the tests. I'll leave it as future work. Another, bigger, issue is that the zip file is removed with `os.remove('temp.zip')` at the end, which is against the task description, so the model should fail this task based on my understanding.
  
- **BigCodeBench/215:** Issue resolved through updates to the tests. `starcoder2-15b` now passes this test in BigCodeBench.

Fixes #33