### PR TITLE
[FIX] trust_remote_code not correctly propagated to vllm/hf

### DIFF
--- a/bigcodebench/provider/__init__.py
+++ b/bigcodebench/provider/__init__.py
@@ -40,6 +40,7 @@ def make_model(
             tp=tp,
             instruction_prefix=instruction_prefix,
             response_prefix=response_prefix,
+            trust_remote_code=trust_remote_code,
         )
     elif backend == "hf":
         from bigcodebench.provider.hf import HuggingFaceDecoder
@@ -56,6 +57,7 @@ def make_model(
             instruction_prefix=instruction_prefix,
             response_prefix=response_prefix,
             attn_implementation=attn_implementation,
+            trust_remote_code=trust_remote_code,
         )
     elif backend == "openai":
         from bigcodebench.provider.openai import OpenAIChatDecoder


### PR DESCRIPTION
When I tried to start `bigcodebench.evaluate` for OpenCoder-8B-Instruct,the `--trust_remote_code True` did not take effect.

my evaluate cli:
```shell
bigcodebench.evaluate \
  --model OpenCoder-8B-Instruct \
  --split complete \
  --trust_remote_code True \
  --subset full \
  --backend vllm
```

After check the code, I found that the `trust_remote_code` parameter was not passed when creating `VllmDecoder` and `HuggingFaceDecoder`.

This pr fixed it.