### PR TITLE
debug passk parsing

### DIFF
--- a/bigcodebench/evaluate.py
+++ b/bigcodebench/evaluate.py
@@ -205,8 +205,7 @@ def evaluate(
     else:
         
         pass_at_k = dict()
-
-        passk = [int(k) for k in pass_k.split(",")]
+        passk = list(pass_k)
         
         if parallel < 1:
             n_workers = max(1, multiprocessing.cpu_count() // 2)


### PR DESCRIPTION
Previously, evaluate gave an error with local execution:
```
/scr/kanishkg/miniconda3/envs/bcb2/lib/python3.10/site-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.16.5 and <1.23.0 is required for this version of SciPy (detected version 1.26.4
  warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
Traceback (most recent call last):
  File "/scr/kanishkg/miniconda3/envs/bcb2/bin/bigcodebench.evaluate", line 8, in <module>
    sys.exit(main())
  File "/scr/kanishkg/miniconda3/envs/bcb2/lib/python3.10/site-packages/bigcodebench/evaluate.py", line 432, in main
    Fire(evaluate)
  File "/sailhome/kanishkg/.local/lib/python3.10/site-packages/fire/core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/sailhome/kanishkg/.local/lib/python3.10/site-packages/fire/core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/sailhome/kanishkg/.local/lib/python3.10/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/scr/kanishkg/miniconda3/envs/bcb2/lib/python3.10/site-packages/bigcodebench/evaluate.py", line 209, in evaluate
    passk = [int(k) for k in pass_k.split(",")]
AttributeError: 'tuple' object has no attribute 'split'
```
this was because pass_k was already parsed and a tuple.
This PR fixes this.