### PR TITLE
fix make_raw_chat_prompt when prefill is disabled

### DIFF
--- a/bigcodebench/provider/utility.py
+++ b/bigcodebench/provider/utility.py
@@ -72,7 +72,7 @@ def make_raw_chat_prompt(
                 [
                     {"role": "user", "content": task_prompt},
                 ],
-                tokenize=False,
+                tokenize=False, add_generation_prompt=True
             ).split(_MAGIC_SPLITTER_)[0]
     return task_prompt
 


### PR DESCRIPTION
This pull request fixes task prompting when prefill is disabled. 

Tested on Deepseek distilled models using vllm, and CoT works normal now.