### PR TITLE
fix e2b sdk version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     google-genai
     mistralai>=0.2.0,<1.0.0
     openai>=1.11.1
-    e2b
+    e2b<=1.11.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
because e2b 2.0 sdk change interface, so install the 1.x e2b sdk to makesure eval work fine

the problem fixed like this:
<img width="712" height="369" alt="image" src="https://github.com/user-attachments/assets/253995e3-4a27-4d1a-98ea-976512ce01aa" />

