### PR TITLE
fix env variable type

### DIFF
--- a/bigcodebench/eval/__init__.py
+++ b/bigcodebench/eval/__init__.py
@@ -179,7 +179,7 @@ def untrusted_check(
     gt_time_limit: float = 60
 ) -> Tuple[str, np.ndarray]:
     min_time_limit = max(min_time_limit, gt_time_limit)
-    timeout = max(os.getenv("BIGCODEBENCH_TIMEOUT_PER_TASK", TIMEOUT_LIMIT), min_time_limit) + 1
+    timeout = max(float(os.getenv("BIGCODEBENCH_TIMEOUT_PER_TASK", TIMEOUT_LIMIT)), min_time_limit) + 1
     # shared memory objects
     stat = Value("i", _UNKNOWN)
     manager = Manager()

--- a/bigcodebench/gen/util/__init__.py
+++ b/bigcodebench/gen/util/__init__.py
@@ -102,7 +102,7 @@ def trusted_check(
     max_stack_limit: float,
     min_time_limit: float = 10,
 ):
-    timeout = max(os.getenv("BIGCODEBENCH_TIMEOUT_PER_TASK", TIMEOUT_LIMIT), min_time_limit) + 1
+    timeout = max(float(os.getenv("BIGCODEBENCH_TIMEOUT_PER_TASK", TIMEOUT_LIMIT)), min_time_limit) + 1
     # shared memory objects
     times = Value("d", -1)
     manager = Manager()


### PR DESCRIPTION
Environment variable ``BIGCODEBENCH_TIMEOUT_PER_TASK`` is in type string, need to cast to float for the math functions.